### PR TITLE
ci/prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"],
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:prettier/recommended",
+    "prettier/react"
+  ],
   "rules": {
     "semi": [2, "always"]
   }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 80,
+  "quoteProps": "as-needed",
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "semi": true,
+  "jsxSingleQuote": false
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,13 @@
-const nextJest = require("next/jest");
+const nextJest = require('next/jest');
 
 const createJestConfig = nextJest({
-  dir: "./",
+  dir: './',
 });
 
 /** @type {import('jest').Config} */
 const customJestConfig = {
-  moduleDirectories: ["node_modules", "<rootDir>/"],
-  testEnvironment: "jest-environment-jsdom",
+  moduleDirectories: ['node_modules', '<rootDir>/'],
+  testEnvironment: 'jest-environment-jsdom',
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,8 @@
-const { createVanillaExtractPlugin } = require("@vanilla-extract/next-plugin");
-const withNextIntl = require("next-intl/plugin")(
-  "./src/domain/locale/matcher.ts"
+const { createVanillaExtractPlugin } = require('@vanilla-extract/next-plugin');
+const withNextIntl = require('next-intl/plugin')(
+  './src/domain/locale/matcher.ts'
 );
-const compose = require("./scripts/compose");
+const compose = require('./scripts/compose');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "format": "prettier \"**/**.(js|ts|tsx)\" --write",
     "test": "jest --watch"
   },
   "browserslist": [
@@ -38,7 +39,9 @@
     "@testing-library/react": "^13.4.0",
     "@vanilla-extract/next-plugin": "^2.1.1",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.4.2",
-    "jest-environment-jsdom": "^29.4.2"
+    "jest-environment-jsdom": "^29.4.2",
+    "prettier": "^2.8.4"
   }
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,13 +1,13 @@
-import { useLocale } from "next-intl";
+import { useLocale } from 'next-intl';
 import { notFound } from 'next/navigation';
-import ReportWebVitals from "../../ui/components/ReportWebVitals";
+import ReportWebVitals from '../../ui/components/ReportWebVitals';
 
 type RootLayoutProps = {
   children: React.ReactNode;
   params: {
     locale: string;
   };
-}
+};
 
 function RootLayout({ children, params }: RootLayoutProps) {
   const locale = useLocale();
@@ -18,11 +18,11 @@ function RootLayout({ children, params }: RootLayoutProps) {
 
   return (
     <html lang={locale}>
-    <head />
-    <body>
-      <ReportWebVitals />
-      {children}
-    </body>
+      <head />
+      <body>
+        <ReportWebVitals />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,11 +1,9 @@
-import { useTranslations } from "next-intl";
+import { useTranslations } from 'next-intl';
 
 function Page() {
   const t = useTranslations('Index');
 
-  return (
-    <h1>{t('title')}</h1>
-  );
+  return <h1>{t('title')}</h1>;
 }
 
 export default Page;

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,4 +1,3 @@
-
 function Head() {
   return null;
 }

--- a/src/domain/lib/report-webvitals.ts
+++ b/src/domain/lib/report-webvitals.ts
@@ -1,9 +1,20 @@
-import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB, CLSReportCallback } from 'web-vitals';
+import {
+  CLSReportCallback,
+  onCLS,
+  onFCP,
+  onFID,
+  onINP,
+  onLCP,
+  onTTFB,
+} from 'web-vitals';
 import { isDev } from './dev';
 
 const logger: CLSReportCallback = ({ name, value, rating }): void =>
   isDev()
-    ? console.log(`reported webvital ${name} with the following data:`, { value, rating })
+    ? console.log(`reported webvital ${name} with the following data:`, {
+        value,
+        rating,
+      })
     : undefined;
 
 const reports = [onCLS, onFCP, onFCP, onINP, onLCP, onTTFB, onFID];

--- a/src/domain/locale/config.ts
+++ b/src/domain/locale/config.ts
@@ -1,10 +1,10 @@
 const config = {
   locale: {
     locales: ['en', 'pt-br'],
-    defaultLocale: 'pt-br'
+    defaultLocale: 'pt-br',
   },
   config: {
-    matcher: ['/((?!_next).*)']
+    matcher: ['/((?!_next).*)'],
   },
 };
 

--- a/src/domain/locale/matcher.ts
+++ b/src/domain/locale/matcher.ts
@@ -1,5 +1,5 @@
-import { getRequestConfig } from "next-intl/server";
+import { getRequestConfig } from 'next-intl/server';
 
-export default getRequestConfig(async ({locale}) => ({
+export default getRequestConfig(async ({ locale }) => ({
   messages: (await import(`./${locale}.json`)).default,
 }));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import {createIntlMiddleware} from 'next-intl/server';
+import { createIntlMiddleware } from 'next-intl/server';
 import i18n from './domain/locale/config';
 
 export default createIntlMiddleware(i18n.locale);

--- a/src/ui/components/Link/index.tsx
+++ b/src/ui/components/Link/index.tsx
@@ -7,7 +7,7 @@ type LinkProps = {
   children: ReactNode;
   href: string;
   locale: AppLocales;
-}
+};
 
 function Link({ children, href, locale }: LinkProps) {
   return (

--- a/src/ui/components/ReportWebVitals.tsx
+++ b/src/ui/components/ReportWebVitals.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { useEffect } from "react";
-import { reportWebVitals } from "../../domain/lib/report-webvitals";
+import { useEffect } from 'react';
+import { reportWebVitals } from '../../domain/lib/report-webvitals';
 
 function ReportWebVitals() {
   useEffect(() => {

--- a/src/ui/styles/fonts.css.ts
+++ b/src/ui/styles/fonts.css.ts
@@ -1,11 +1,11 @@
 import { globalFontFace } from '@vanilla-extract/css';
 
 const fonts = {
-  Roboto: 'Roboto'
+  Roboto: 'Roboto',
 };
 
 globalFontFace('Roboto', {
-  src: 'local("Roboto")'
+  src: 'local("Roboto")',
 });
 
 export default fonts;

--- a/src/ui/styles/global.css.ts
+++ b/src/ui/styles/global.css.ts
@@ -4,7 +4,7 @@ import fonts from './fonts.css';
 globalStyle('*', {
   margin: 0,
   padding: 0,
-  boxSizing: 'border-box'
+  boxSizing: 'border-box',
 });
 
 globalStyle('html, body', {

--- a/src/ui/styles/sprinkles.css.ts
+++ b/src/ui/styles/sprinkles.css.ts
@@ -5,7 +5,7 @@ const colorProps = defineProperties({
   properties: {
     color: colors,
     background: colors,
-  }
+  },
 });
 
 const responsiveProps = defineProperties({
@@ -20,19 +20,14 @@ const responsiveProps = defineProperties({
       'center',
       'flex-end',
       'space-around',
-      'space-between'
+      'space-between',
     ],
-    alignItems: [
-      'stretch',
-      'flex-start',
-      'center',
-      'flex-end'
-    ],
+    alignItems: ['stretch', 'flex-start', 'center', 'flex-end'],
     paddingTop: space,
     paddingBottom: space,
     paddingLeft: space,
-    paddingRight: space
-  }
+    paddingRight: space,
+  },
 });
 
 const sprinkles = createSprinkles(colorProps, responsiveProps);

--- a/src/ui/styles/tokens.css.ts
+++ b/src/ui/styles/tokens.css.ts
@@ -1,17 +1,17 @@
 export const colors = {
-  'gray.100': '#fff'
+  'gray.100': '#fff',
 };
 
 export const space = {
-  '0': 0
+  '0': 0,
 };
 
 export const responsive = {
   mobile: {},
   tablet: {
-    '@media': ''
+    '@media': '',
   },
   desktop: {
-    '@media': ''
-  }
+    '@media': '',
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,6 +2030,13 @@ eslint-plugin-jsx-a11y@^6.5.1:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
+eslint-plugin-prettier@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
+  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^4.5.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -2217,6 +2224,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
@@ -3850,6 +3862,18 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
 pretty-format@^27.0.2:
   version "27.5.1"


### PR DESCRIPTION
- chore: recreate all initial project, reconfigure initial deps and create new arch
- chore: configure vanilla-extract lib
- build(package.json): bump deps
- feat: configure i18n
- refactor(i18n): reorganize config
- refactor(next.config.js): create fn to compose all nextjs plugins
- feat(styles): configure sprinkles
- feat(styles): configure global styles
- feat(styles): configure styled
- feat(styles): configure font styles
- feat(styles): configure tokens
- feat(webvitals): configure to rating of webvital metrics
- feat(package.json): configure browserslist
- ci: configure prettier to improve code style guide
